### PR TITLE
Support standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ a11y --url https://localhost:3000 --out ./reports/
 
 ## API
 
-| Command line option | Descriptopn                                     | Example               | Required |
-| ------------------- | ----------------------------------------------- | --------------------- | -------- |
-| `--url`             | Specify the url to look into                    | http://localhost:3000 | **Yes**  |
-| `--out`             | Specify the output directoty for stored reports | ./reports/            | **No**   |
+| Command line option | Descriptopn                                                                                 | Example               | Required | Default |
+| :------------------ | :------------------------------------------------------------------------------------------ | :-------------------- | :------: | :-----: |
+| `--url`             | Specify the url to look into                                                                | http://localhost:3000 | **Yes**  |    -    |
+| `--out`             | Specify the output directoty for stored reports                                             | ./reports/            |  **No**  |   ./    |
+| `--standard`        | Specify the standard to test against (Supported Standards: `WCAG2A`,`WCAG2AA`,`Section508`) | Section508            |  **No**  | WCAG2A  |
+
+> Note: `--out` will create all parent directories that do not exist recursively!
+
+> Note: Standards are case sensitive!
 
 ## Roadmap
 

--- a/lib/a11y.ts
+++ b/lib/a11y.ts
@@ -102,7 +102,7 @@ function main() {
     })
   );
 
-  runA11y(url, Object.assign({}, defaultOptions, options));
+  runA11y(url, options);
 }
 
 // Run main

--- a/lib/runners/axeCore.ts
+++ b/lib/runners/axeCore.ts
@@ -1,15 +1,22 @@
 import { AxePuppeteer } from "axe-puppeteer";
 import puppeteer from "puppeteer";
-import { Report } from "../types";
+import { Report, Runner, A11yOptions } from "../types";
 
-export async function runAxeCore(url: string) {
+export async function runAxeCore(url: string, options: A11yOptions) {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   await page.setBypassCSP(true);
 
   await page.goto(url);
 
-  const results = await new AxePuppeteer(page).analyze();
+  const results = await new AxePuppeteer(page)
+    .options({
+      runOnly: {
+        type: "tag",
+        values: [options.standard.toLowerCase()] // Axe core can run multiple standards but this needs to be one to support one standard rule of pa11y
+      }
+    })
+    .analyze();
 
   const title = await page.title();
 
@@ -19,8 +26,8 @@ export async function runAxeCore(url: string) {
   return { results, documentTitle: title };
 }
 
-export async function runWithAxeCore(url: string) {
-  const { results, documentTitle } = await runAxeCore(url);
+export const runWithAxeCore: Runner = async (url, options) => {
+  const { results, documentTitle } = await runAxeCore(url, options);
   const report: Report = {
     documentTitle,
     pageUrl: results.url,
@@ -29,4 +36,4 @@ export async function runWithAxeCore(url: string) {
     notices: results.inapplicable
   };
   return report;
-}
+};

--- a/lib/runners/pa11y.ts
+++ b/lib/runners/pa11y.ts
@@ -1,9 +1,9 @@
 import pa11y from "pa11y";
 import { Report, Runner, Pa11yOptions } from "../types";
 
-export const runWithPa11y: Runner = async (url: string) => {
+export const runWithPa11y: Runner = async (url, options) => {
   const pa11yOptions: Partial<Pa11yOptions> = {
-    standard: "WCAG2A",
+    standard: options.standard,
     includeNotices: true,
     includeWarnings: true
   };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,10 +9,17 @@ export type Report = {
   pageUrl: string;
 };
 
-export type Runner = (url: string) => Promise<Report>;
-export interface A11yOptions {
+export type SupportedStandard = "WCAG2A" | "WCAG2AA" | "Section508";
+export type SupportedOptions = {
+  standard: SupportedStandard;
+};
+
+export type Runner = (url: string, options: A11yOptions) => Promise<Report>;
+export type A11yArguments = {
   out: string;
-}
+  url: string;
+};
+export interface A11yOptions extends SupportedOptions, A11yArguments {}
 
 export type AxeCoreResult = axe.AxeResults;
 
@@ -35,7 +42,7 @@ export type Pa11yOptions = {
   rootElement: string | null;
   rules: string[];
   screenCapture: string | null;
-  standard: "Section508" | "WCAG2A" | "WCAG2AA" | "WCAG2AAA";
+  standard: SupportedStandard;
   timeout: number;
   userAgent: string;
   viewport: {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,8 @@
+// TODO: add better typing
+export function objectWithNoFalsyValue(obj: { [k: string]: any }) {
+  return Object.keys(obj)
+    .filter(k => !!obj[k])
+    .reduce<any>((result, current) => {
+      return { ...result, [current]: obj[current] };
+    }, {});
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "rm -rf dist && tsc",
     "start": "tsc --watch",
     "test:cli:no-url": "yarn build && node dist/a11y.js",
-    "test:cli": "rm -rf ./reports && yarn build && node dist/a11y.js --url https://google.com --out ./reports",
+    "test:cli": "rm -rf ./reports && yarn build && node dist/a11y.js --url https://farzadyz.com --out ./reports --standard Section508",
     "prepublish": "npm run build"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@farskid/a11y",
   "description": "Automated Accessibility tests",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "Farzad YZ",
     "email": "farskid@gmail.com",


### PR DESCRIPTION
Adds support for `--standard` argument.

Currently supported standards:

- **WCAG2A**
- **WCAG2AA**
- **Section508**